### PR TITLE
ci: update actions/checkout to v3

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -16,7 +16,7 @@ jobs:
         node: [16]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node v${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
@@ -38,7 +38,7 @@ jobs:
         node: [16]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node v${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
@@ -60,7 +60,7 @@ jobs:
         node: [16]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node v${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
@@ -81,7 +81,7 @@ jobs:
         node: [16]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node v${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
@@ -102,7 +102,7 @@ jobs:
         node: [16]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: 'github-check'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

Updated actions/checkout to v3, which fixes the Node.js 12 deprecation warning.

### Additional context

This warning is appearing in every action run ([example](https://github.com/dalbitresb12/easyleasing-app/actions/runs/3521289497)).
